### PR TITLE
assembly rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+.ccls-cache/

--- a/vendor/dune
+++ b/vendor/dune
@@ -1,55 +1,171 @@
-; There are 4 configrations for the blake3 rules:
+; There are 3 configrations for the blake3 rules:
 ; 1. Handwritten assembly for x86_64
 ; 2. SIMD instructions with neon intrinsics for arm64
-; 3. SIMD instructions with x86 intrinsics for amd64
-; 4. Portable C implementation
+; 3. Portable C implementation
 
-; We only handle the last 3 configurations here.
-
-; x86 intrinsics
+; 1. Handwritten assembly for x86_64
 
 (foreign_library
  (enabled_if
   (= %{architecture} "amd64"))
  (archive_name blake3)
  (language c)
- (flags :standard -O2)
  (names blake3 blake3_portable blake3_dispatch)
- (extra_objects blake3_avx2 blake3_avx512 blake3_sse2 blake3_sse41))
+ (extra_objects
+  blake3_avx2_x86-64
+  blake3_avx512_x86-64
+  blake3_sse2_x86-64
+  blake3_sse41_x86-64))
+
+; 1.1: Unix assembly for x86_64
 
 (rule
  (enabled_if
-  (= %{architecture} "amd64"))
- (deps blake3_avx2.c)
- (targets blake3_avx2%{ext_obj})
+  (and
+   (= %{architecture} "amd64")
+   (or
+    (= %{system} "linux")
+    (= %{system} "macosx"))))
+ (deps blake3_avx2_x86-64_unix.S)
+ (targets blake3_avx2_x86-64%{ext_obj})
  (action
-  (run %{cc} -mavx2 -c %{deps} -o %{targets})))
+  (run %{cc} -c %{deps} -o %{targets})))
 
 (rule
  (enabled_if
-  (= %{architecture} "amd64"))
- (deps blake3_avx512.c)
- (targets blake3_avx512%{ext_obj})
+  (and
+   (= %{architecture} "amd64")
+   (or
+    (= %{system} "linux")
+    (= %{system} "macosx"))))
+ (deps blake3_avx512_x86-64_unix.S)
+ (targets blake3_avx512_x86-64%{ext_obj})
  (action
-  (run %{cc} -mavx512f -mavx512vl -mavx512bw -c %{deps} -o %{targets})))
+  (run %{cc} -c %{deps} -o %{targets})))
 
 (rule
  (enabled_if
-  (= %{architecture} "amd64"))
- (deps blake3_sse2.c)
- (targets blake3_sse2%{ext_obj})
+  (and
+   (= %{architecture} "amd64")
+   (or
+    (= %{system} "linux")
+    (= %{system} "macosx"))))
+ (deps blake3_sse2_x86-64_unix.S)
+ (targets blake3_sse2_x86-64%{ext_obj})
  (action
-  (run %{cc} -msse2 -c %{deps} -o %{targets})))
+  (run %{cc} -c %{deps} -o %{targets})))
 
 (rule
  (enabled_if
-  (= %{architecture} "amd64"))
- (deps blake3_sse41.c)
- (targets blake3_sse41%{ext_obj})
+  (and
+   (= %{architecture} "amd64")
+   (or
+    (= %{system} "linux")
+    (= %{system} "macosx"))))
+ (deps blake3_sse41_x86-64_unix.S)
+ (targets blake3_sse41_x86-64%{ext_obj})
  (action
-  (run %{cc} -msse4.1 -c %{deps} -o %{targets})))
+  (run %{cc} -c %{deps} -o %{targets})))
 
-; neon intrinsics
+; 1.2: Windows GNU assembly for x86_64
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{system} "mingw64")
+   (<> %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_avx2_x86-64_windows_gnu.S)
+ (targets blake3_avx2_x86-64%{ext_obj})
+ (action
+  (run %{cc} -c %{deps} -o %{targets})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{system} "mingw64")
+   (<> %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_avx512_x86-64_windows_gnu.S)
+ (targets blake3_avx512_x86-64%{ext_obj})
+ (action
+  (run %{cc} -c %{deps} -o %{targets})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{system} "mingw64")
+   (<> %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_sse2_x86-64_windows_gnu.S)
+ (targets blake3_sse2_x86-64%{ext_obj})
+ (action
+  (run %{cc} -c %{deps} -o %{targets})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{system} "mingw64")
+   (<> %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_sse41_x86-64_windows_gnu.S)
+ (targets blake3_sse41_x86-64%{ext_obj})
+ (action
+  (run %{cc} -c %{deps} -o %{targets})))
+
+; 1.3: Windows MSVC assembly for x86_64
+
+; %{ocaml-config:asm} has other flags that we don't want
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_avx2_x86-64_windows_msvc.asm)
+ (targets blake3_avx2_x86-64%{ext_obj})
+ (action
+  (run %{bin:ml64} /nologo /quiet /Fo%{targets} /c %{deps})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_avx512_x86-64_windows_msvc.asm)
+ (targets blake3_avx512_x86-64%{ext_obj})
+ (action
+  (run %{bin:ml64} /nologo /quiet /Fo%{targets} /c %{deps})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_sse2_x86-64_windows_msvc.asm)
+ (targets blake3_sse2_x86-64%{ext_obj})
+ (action
+  (run %{bin:ml64} /nologo /quiet /Fo%{targets} /c %{deps})))
+
+(rule
+ (enabled_if
+  (and
+   (= %{architecture} "amd64")
+   (= %{os_type} "Win32")
+   (= %{ocaml-config:ccomp_type} "msvc")))
+ (deps blake3_sse41_x86-64_windows_msvc.asm)
+ (targets blake3_sse41_x86-64%{ext_obj})
+ (action
+  (run %{bin:ml64} /nologo /quiet /Fo%{targets} /c %{deps})))
+
+; 2. SIMD instructions with neon intrinsics for arm64
 
 (foreign_library
  (enabled_if
@@ -58,22 +174,30 @@
    (= %{architecture} "aarch64")))
  (archive_name blake3)
  (language c)
- (flags :standard -O2)
  (names blake3 blake3_portable blake3_dispatch blake3_neon))
 
-; portable C implementation
+; 3. Portable C implementation
 
 (foreign_library
  (enabled_if
   (and
-   (<> %{architecture} "amd64")
-   (<> %{architecture} "arm64")
-   (<> %{architecture} "aarch64")))
+   (not
+    (and
+     (= %{architecture} "amd64")
+     (or
+      (= %{os_type} "Win32")
+      (= %{system} "win64")
+      (= %{system} "mingw64")
+      (= %{system} "linux")
+      (= %{system} "macosx"))))
+   (not
+    (or
+     (= %{architecture} "arm64")
+     (= %{architecture} "aarch64")))))
  (archive_name blake3)
  (language c)
  (flags
   :standard
-  -O2
   "-DBLAKE3_NO_SSE2"
   "-DBLAKE3_NO_SSE41"
   "-DBLAKE3_NO_AVX2"


### PR DESCRIPTION
In this PR we add the assembly rules for all platforms and architectures and test all of them in the CI.

Depends on:
- [x] https://github.com/rgrinberg/ocaml-blake3-mini/pull/10
- [x] https://github.com/rgrinberg/ocaml-blake3-mini/pull/11
- [x] https://github.com/rgrinberg/ocaml-blake3-mini/pull/12
- [x] https://github.com/rgrinberg/ocaml-blake3-mini/pull/13
- [x] https://github.com/rgrinberg/ocaml-blake3-mini/pull/14