### PR TITLE
blake3_stubs: add conditional win32 equivalent

### DIFF
--- a/src/blake3_stubs.c
+++ b/src/blake3_stubs.c
@@ -117,7 +117,7 @@ CAMLprim value blake3_mini_feed_bigstring_unlock(value v_t, value v_s,
   blake3_hasher *hasher = Blake3_val(v_t);
   size_t pos = Long_val(v_pos);
   size_t len = Long_val(v_len);
-  void *s = Caml_ba_data_val(v_s);
+  char *s = Caml_ba_data_val(v_s);
   caml_register_global_root(&v_s);
   caml_release_runtime_system();
   blake3_hasher_update(hasher, s + pos, len);

--- a/src/blake3_stubs.c
+++ b/src/blake3_stubs.c
@@ -9,8 +9,6 @@
 #include <caml/threads.h>
 #include <caml/unixsupport.h>
 
-#include <unistd.h>
-
 #include "blake3.h"
 
 #define Blake3_val(v) (*(blake3_hasher **)Data_custom_val(v))


### PR DESCRIPTION
- Windows doesn't have `unistd.h` so we use an equivalent function from `io.h`.
- msvc complains about not being able to determine the size of `void *` so we change to `char *`.